### PR TITLE
chore: bump version to v0.5.0

### DIFF
--- a/gptscript/command.py
+++ b/gptscript/command.py
@@ -5,7 +5,7 @@ from gptscript.exec_utils import exec_cmd, stream_exec_cmd
 from gptscript.tool import FreeForm, Tool
 
 optToArg = {
-    "cache": "--cache=",
+    "cache": "--disable-cache=",
     "cacheDir": "--cache-dir=",
 }
 
@@ -92,7 +92,10 @@ def toArgs(opts):
     args = ["--quiet=false"]
     for opt, val in opts.items():
         if optToArg.get(opt):
-            args.append(optToArg[opt] + val)
+            if opt == "cache":
+                args.append(optToArg[opt] + str(not val))
+            else:
+                args.append(optToArg[opt] + val)
     return args
 
 

--- a/gptscript/install.py
+++ b/gptscript/install.py
@@ -26,7 +26,7 @@ else:
 gptscript_info = {
     "name": "gptscript",
     "url": "https://github.com/gptscript-ai/gptscript/releases/download/",
-    "version": "v0.4.2",
+    "version": "v0.5.0",
 }
 
 pltfm = {"windows": "windows", "linux": "linux", "darwin": "macOS"}.get(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gptscript"
-version = "0.4.2"
+version = "0.5.0"
 description = "Run gptscripts from Python apps"
 readme = "README.md"
 authors = [{ name = "Bill Maxwell", email = "bill@acorn.io" }]

--- a/scripts/package
+++ b/scripts/package
@@ -17,7 +17,7 @@ from tempfile import TemporaryDirectory
 gptscript_info = {
     "name": "gptscript",
     "url": "https://github.com/gptscript-ai/gptscript/releases/download/",
-    "version": "v0.4.2",
+    "version": "v0.5.0",
 }
 
 # Define platform-specific variables

--- a/tests/test_gptscript.py
+++ b/tests/test_gptscript.py
@@ -88,7 +88,8 @@ def test_exec_simple_tool(simple_tool):
 
 # Test execution of a complex tool
 def test_exec_complex_tool(complex_tool):
-    out, err = exec(complex_tool)
+    opts = {"cache": False}
+    out, err = exec(complex_tool, opts=opts)
     assert out is not None, "Expected some output from exec using complex_tool"
 
 


### PR DESCRIPTION
Bump version of gptscript to v0.5.0
Update flag to use --disable-cache, same API
modified test to include exercising cache