### PR TITLE
Chore: bump gptscript version

### DIFF
--- a/gptscript/install.py
+++ b/gptscript/install.py
@@ -26,7 +26,7 @@ else:
 gptscript_info = {
     "name": "gptscript",
     "url": "https://github.com/gptscript-ai/gptscript/releases/download/",
-    "version": "v0.5.0",
+    "version": "v0.7.1",
 }
 
 pltfm = {"windows": "windows", "linux": "linux", "darwin": "macOS"}.get(


### PR DESCRIPTION
The gptscript is out-of-date. need to update this so that knowledge e2e test can use latest gptscript.