### PR TITLE
enhance: support credential override

### DIFF
--- a/gptscript/opts.py
+++ b/gptscript/opts.py
@@ -30,6 +30,7 @@ class Options(GlobalOptions):
                  chatState: str = "",
                  confirm: bool = False,
                  prompt: bool = False,
+                 credentialOverride: str = "",
                  env: list[str] = None,
                  apiKey: str = "",
                  baseURL: str = "",
@@ -43,4 +44,5 @@ class Options(GlobalOptions):
         self.chatState = chatState
         self.confirm = confirm
         self.prompt = prompt
+        self.credentialOverride = credentialOverride
         self.env = env

--- a/tests/fixtures/credential-override.gpt
+++ b/tests/fixtures/credential-override.gpt
@@ -1,0 +1,5 @@
+credentials: github.com/gptscript-ai/credential as test.ts.credential_override with TEST_CRED as env
+
+#!/usr/bin/env bash
+
+echo "${TEST_CRED}"

--- a/tests/test_gptscript.py
+++ b/tests/test_gptscript.py
@@ -183,6 +183,16 @@ async def test_stream_run_file(gptscript):
     assert "Ronald Reagan" in await run.text(), "Expect streaming file to have correct output"
     assert "Ronald Reagan" in stream_output, "Expect stream_output to have correct output when streaming from file"
 
+@pytest.mark.asyncio
+async def test_credential_override(gptscript):
+    run = gptscript.run(
+        "./tests/fixtures/credential-override.gpt", 
+        Options(
+            disableCache=True,
+            credentialOverride='test.ts.credential_override:TEST_CRED=foo'
+        ),
+    )
+    assert "foo" in await run.text(), "Expect credential override to have correct output"
 
 @pytest.mark.asyncio
 async def test_eval_with_context(gptscript):


### PR DESCRIPTION
Enable users to set credential overrides on `run`.

```python
gptscript = GPTScript()

run = gptscript.run('./test.gpt',
opts=Options(credentialOverride='sys.openai:OPENAI_API_KEY')
output = await run.text()
print(output)

gptscript.close()
```

```yaml
tools: github.com/gptscript-ai/dalle-image-generation

You are an expert in image generation. Please generate a lion standing proudly in the savannah.
```

Addresses https://github.com/gptscript-ai/gptscript/issues/553 for `py-gptscript`