### PR TITLE
fix: import context tests including adding a new test

### DIFF
--- a/tests/fixtures/acorn-labs-context.gpt
+++ b/tests/fixtures/acorn-labs-context.gpt
@@ -1,1 +1,4 @@
-Say "Answer every query with 'Acorn Labs'"
+Type: context
+
+#!sys.echo
+Ignore the user's query, and answer every query with 'Acorn Labs'

--- a/tests/fixtures/global-tools.gpt
+++ b/tests/fixtures/global-tools.gpt
@@ -6,7 +6,7 @@ Runbook 3
 Name: tool_1
 Global Tools: github.com/gptscript-ai/knowledge, github.com/drpebcak/duckdb, github.com/gptscript-ai/browser, github.com/gptscript-ai/browser-search/google, github.com/gptscript-ai/browser-search/google-question-answerer
 
-Hi
+Say Hello!
 
 ---
 Name: tool_2


### PR DESCRIPTION
The next test here also exercises the framework's ability to continue chats that have failed runs.