### PR TITLE
chore: add credentialContexts to GlobalOptions

### DIFF
--- a/gptscript/opts.py
+++ b/gptscript/opts.py
@@ -58,6 +58,7 @@ class Options(GlobalOptions):
                  confirm: bool = False,
                  prompt: bool = False,
                  credentialOverrides: list[str] = None,
+                 credentialContexts: list[str] = None,
                  location: str = "",
                  env: list[str] = None,
                  forceSequential: bool = False,
@@ -76,6 +77,7 @@ class Options(GlobalOptions):
         self.confirm = confirm
         self.prompt = prompt
         self.credentialOverrides = credentialOverrides
+        self.credentialContexts = credentialContexts
         self.location = location
         self.env = env
         self.forceSequential = forceSequential
@@ -92,6 +94,7 @@ class Options(GlobalOptions):
         cp.confirm = self.confirm
         cp.prompt = self.prompt
         cp.credentialOverrides = self.credentialOverrides
+        cp.credentialContexts = self.credentialContexts
         cp.location = self.location
         cp.env = self.env
         cp.forceSequential = self.forceSequential

--- a/tests/fixtures/global-tools.gpt
+++ b/tests/fixtures/global-tools.gpt
@@ -4,7 +4,7 @@ Runbook 3
 
 ---
 Name: tool_1
-Global Tools: github.com/gptscript-ai/knowledge, github.com/drpebcak/duckdb, github.com/gptscript-ai/browser, github.com/gptscript-ai/browser-search/google, github.com/gptscript-ai/browser-search/google-question-answerer
+Global Tools: github.com/drpebcak/duckdb, github.com/gptscript-ai/browser, github.com/gptscript-ai/browser-search/google, github.com/gptscript-ai/browser-search/google-question-answerer
 
 Say Hello!
 


### PR DESCRIPTION
This is so that SDK users can specify credential contexts when using functions like `run` and `evaluate`.