### PR TITLE
fix: add pydantic to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "requests==2.31.0",
     "tqdm==4.66.2",
     "urllib3==2.2.1",
+    "pydantic==2.9.2",
     "pywin32==306 ; sys_platform == 'win32'",
 ]
 


### PR DESCRIPTION
Apparently you have to list the dependencies here too.