### PR TITLE
enhance: add functions for daemon tools to do mTLS

### DIFF
--- a/gptscript/daemon.py
+++ b/gptscript/daemon.py
@@ -1,0 +1,47 @@
+import base64
+import ssl
+import os
+import tempfile
+
+
+def start_fastapi(app):
+    cert, key, client_cert = save_certificates_from_env()
+    import uvicorn
+    uvicorn.run(
+        app,
+        host="127.0.0.1",
+        port=int(os.getenv("PORT")),
+        ssl_certfile=cert,
+        ssl_keyfile=key,
+        ssl_ca_certs=client_cert,
+        ssl_cert_reqs=ssl.CERT_REQUIRED,
+    )
+
+def save_certificates_from_env():
+    cert = base64.b64decode(os.getenv("CERT", ""))
+    key = base64.b64decode(os.getenv("PRIVATE_KEY", ""))
+    client_cert = base64.b64decode(os.getenv("GPTSCRIPT_CERT", ""))
+
+    if cert == "":
+        print("error: CERT env var is empty")
+        exit(1)
+    elif key == "":
+        print("error: PRIVATE_KEY env var is empty")
+        exit(1)
+    elif client_cert == "":
+        print("error: GPTSCRIPT_CERT env var is empty")
+        exit(1)
+
+    cert_file = tempfile.NamedTemporaryFile(delete=False, suffix=".pem")
+    key_file = tempfile.NamedTemporaryFile(delete=False, suffix=".pem")
+    client_cert_file = tempfile.NamedTemporaryFile(delete=False, suffix=".pem")
+
+    cert_file.write(cert)
+    key_file.write(key)
+    client_cert_file.write(client_cert)
+
+    cert_file.close()
+    key_file.close()
+    client_cert_file.close()
+
+    return cert_file.name, key_file.name, client_cert_file.name

--- a/gptscript/daemon.py
+++ b/gptscript/daemon.py
@@ -6,6 +6,13 @@ import tempfile
 
 def start_uvicorn(app):
     cert, key, client_cert = save_certificates_from_env()
+
+    @app.on_event("shutdown")
+    def cleanup():
+        os.remove(cert)
+        os.remove(key)
+        os.remove(client_cert)
+
     import uvicorn
     uvicorn.run(
         app,

--- a/gptscript/daemon.py
+++ b/gptscript/daemon.py
@@ -43,6 +43,10 @@ def save_certificates_from_env():
     key_file = tempfile.NamedTemporaryFile(delete=False, suffix=".pem")
     client_cert_file = tempfile.NamedTemporaryFile(delete=False, suffix=".pem")
 
+    os.chmod(cert_file.name, 0o600)
+    os.chmod(key_file.name, 0o600)
+    os.chmod(client_cert_file.name, 0o600)
+
     cert_file.write(cert)
     key_file.write(key)
     client_cert_file.write(client_cert)

--- a/gptscript/daemon.py
+++ b/gptscript/daemon.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 
 
-def start_fastapi(app):
+def start_uvicorn(app):
     cert, key, client_cert = save_certificates_from_env()
     import uvicorn
     uvicorn.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "urllib3==2.2.1",
     "pydantic==2.9.2",
     "pywin32==306 ; sys_platform == 'win32'",
+    "uvicorn==0.32.1",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ build==1.1.1
 httpx==0.27.0
 pydantic==2.9.2
 pywin32==306; sys_platform == 'win32'
+uvicorn==0.32.1


### PR DESCRIPTION
This adds a function to set up uvicorn for daemon tools. Uvicorn is the HTTP server that we use in our daemon tools in Python.

The test failures are nothing new and have appeared in other PRs. Probably just something that changed that we need to fix at some point.